### PR TITLE
Add support for image/webp mime-type

### DIFF
--- a/conf.d/000-mime.conf
+++ b/conf.d/000-mime.conf
@@ -26,6 +26,7 @@ mimetype.assign = (
   ".xbm"          =>      "image/x-xbitmap",
   ".xpm"          =>      "image/x-xpixmap",
   ".xwd"          =>      "image/x-xwindowdump",
+  ".webp"         =>      "image/webp",
   ".css"          =>      "text/css",
   ".html"         =>      "text/html",
   ".htm"          =>      "text/html",


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [x] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

<!-- What does this PR do? -->
Adds a mime-type definition for webp.

**Motivation**

As per https://caniuse.com/webp webp is supported by current versions of all modern browsers. Without this definition some scenarios where webp images are used trigger a download instead of displaying an image.

**Checklist**

- [ ] I have read the **CONTRIBUTING** document. (Unable to find said document, not in the source repo.)
- [x] I have read and accepted the **Code of conduct**
- [ ] Tests passes.
- [ ] Style lints passes.
- [ ] Documentation of new public methods exists.
<!-- The following are only needed if this is a new feature. -->
<!-- - [ ] New tests added which covers the added code. -->
<!-- - [ ] Documentation is updated. -->
<!-- - [ ] This PR includes breaking changes. -->
